### PR TITLE
Add a parameter to specify if the export displays column headers or not

### DIFF
--- a/refine.py
+++ b/refine.py
@@ -63,11 +63,12 @@ class RefineProject:
     
     return response_json['code'] # can be 'ok' or 'pending'
   
-  def export_rows(self, format='tsv'):
+  def export_rows(self, format='tsv', printColumnHeader=True):
     data = {
       'engine' : '{"facets":[],"mode":"row-based"}',
       'project' : self.id,
-      'format' : format
+      'format' : format,
+      'printColumnHeader': printColumnHeader
     }
     response = urllib2.urlopen(self.server + '/command/core/export-rows/' + self.project_name + '.' + format, data)
     return response.read()


### PR DESCRIPTION
Hi, 

I used your project and it saved me some time, thanks! 

I just added a parameter to the export_rows function so that we can specify if we want to print the column headers in the output or not. By default, it was always printing them. 

I thought that it might be useful for other people as well. 

Thanks
G.
